### PR TITLE
Replace href placeholder with Stripe product URLs

### DIFF
--- a/index.htm
+++ b/index.htm
@@ -82,7 +82,7 @@
                         <p class="lead fw-normal text-muted mb-0">Stand out. Stay ahead.</p>
                     </div>
                     <div class="row gx-5 justify-content-center">
-                        <!-- Pricing card free-->
+                        <!-- Pricing card lite-->
                         <div class="col-lg-6 col-xl-4">
                             <div class="card mb-5 mb-xl-0">
                                 <div class="card-body p-5">
@@ -125,7 +125,7 @@
                                             Priority Support
                                         </li>
                                     </ul>
-                                    <div class="d-grid"><a class="btn btn-outline-primary" href="#">Choose plan</a></div>
+                                    <div class="d-grid"><a class="btn btn-outline-primary" href="https://buy.stripe.com/fZe2a94385vf9H2eUW">Choose plan</a></div>
                                 </div>
                             </div>
                         </div>
@@ -175,7 +175,7 @@
                                             Priority Support
                                         </li>
                                     </ul>
-                                    <div class="d-grid"><a class="btn btn-primary" href="#">Choose plan</a></div>
+                                    <div class="d-grid"><a class="btn btn-primary" href="https://buy.stripe.com/fZe4ih6bgg9T5qM145">Choose plan</a></div>
                                 </div>
                             </div>
                         </div>
@@ -222,7 +222,7 @@
                                             Priority Support
                                         </li>
                                     </ul>
-                                    <div class="d-grid"><a class="btn btn-outline-primary" href="#">Choose plan</a></div>
+                                    <div class="d-grid"><a class="btn btn-outline-primary" href="https://buy.stripe.com/00g165arw1eZdXi288">Choose plan</a></div>
                                 </div>
                             </div>
                         </div>


### PR DESCRIPTION
### Summary

This PR replaces the `href` placeholder values with my Stripe product URLs. 

### Changes

- Add Stripe links to the pricing cards' `Choose plan` buttons.
- Change comment to `lite` for the Lite product offering. 

### Validation

![image](https://github.com/user-attachments/assets/5603fbca-7221-4f76-a151-ad81a1344731)
